### PR TITLE
Fix inconsistency between Entity/Chat and schema migration

### DIFF
--- a/Migrations/Schema/v1_0/DemacMediaOroLivechatIntegrationBundle.php
+++ b/Migrations/Schema/v1_0/DemacMediaOroLivechatIntegrationBundle.php
@@ -34,7 +34,7 @@ class DemacMediaOroLivechatIntegrationBundle implements Migration
         $table->addColumn('chat_type',                  'string', ['notnull' => false, 'length' => 32]);
         $table->addColumn('chat_id',                    'string', ['notnull' => true, 'length' => 32]);
         $table->addColumn('chat_visitor_name',          'string', ['notnull' => false]);
-        $table->addColumn('chat_visitor_id',            'string', ['notnull' => true, 'length' => 32]);
+        $table->addColumn('chat_visitor_id',            'string', ['notnull' => false, 'length' => 32]);
         $table->addColumn('chat_visitor_ip',            'string', ['notnull' => false, 'length' => 32]);
         $table->addColumn('chat_visitor_email',         'string', ['notnull' => false]);
         $table->addColumn('chat_visitor_city',          'string', ['notnull' => false]);


### PR DESCRIPTION
In Entity/Chat, chat_visitor_id is nullable, in the migration, it's spec'd as notnull=true.  It seems like it should be nullable, as not all visitors are required to enter email and/or name's.  If this is incorrect behavior, there would have to be another mechanism for generating the id
